### PR TITLE
Update config.yml

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -6,6 +6,7 @@ After:
 SilverStripe\Admin\LeftAndMain:
   extra_requirements_javascript:
     - 'vendor/flxlabs/silverstripe-dataobject-links/client/dist/js/sslink-dataobject-transforms.js'
+    - 'vendor/flxlabs/silverstripe-dataobject-links : client/dist/js/de.js'
   extensions:
     - FLXLabs\DataObjectLink\DataObjectLinkExtension
 


### PR DESCRIPTION
Conflict with translating
CMS.LINKLABEL_PAGE
vs.
CMS.LINKLABEL_DATAOBJECT

and add a  de.js - file

```
if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
	if (typeof(console) !== 'undefined') { // eslint-disable-line no-console
		console.error('Class ss.i18n not defined');  // eslint-disable-line no-console
	}
} else {
	ss.i18n.addDictionary('de', {
		"CMS.LINKLABEL_DATAOBJECT": "Link zu DataObject"
		
	});
} 
```